### PR TITLE
ADD uri检查列表，同一个IP不能频繁请求这个列表中的uri，遵循CC的策略

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ ngx_lua_waf是我刚入职趣游时候开发的一个基于ngx_lua的web应用�
 现在开源出来，遵从MIT许可协议。其中包含我们的过滤规则。如果大家有什么建议和想fa，欢迎和我一起完善。
 
 ###用途：
-    	
-	防止sql注入，本地包含，部分溢出，fuzzing测试，xss,SSRF等web攻击
-	防止svn/备份之类文件泄漏
-	防止ApacheBench之类压力测试工具的攻击
-	屏蔽常见的扫描黑客工具，扫描器
-	屏蔽异常的网络请求
-	屏蔽图片附件类目录php执行权限
-	防止webshell上传
+        
+    防止sql注入，本地包含，部分溢出，fuzzing测试，xss,SSRF等web攻击
+    防止svn/备份之类文件泄漏
+    防止ApacheBench之类压力测试工具的攻击
+    屏蔽常见的扫描黑客工具，扫描器
+    屏蔽异常的网络请求
+    屏蔽图片附件类目录php执行权限
+    防止webshell上传
 
 ###推荐安装:
 
@@ -34,7 +34,7 @@ nginx安装路径假设为:/usr/local/nginx/conf/
         lua_package_path "/usr/local/nginx/conf/waf/?.lua";
         lua_shared_dict limit 10m;
         init_by_lua_file  /usr/local/nginx/conf/waf/init.lua; 
-    	access_by_lua_file /usr/local/nginx/conf/waf/waf.lua;
+        access_by_lua_file /usr/local/nginx/conf/waf/waf.lua;
 
 配置config.lua里的waf规则目录(一般在waf/conf/目录下)
 
@@ -47,7 +47,7 @@ nginx安装路径假设为:/usr/local/nginx/conf/
 
 ###配置文件详细说明：
 
-    	RulePath = "/usr/local/nginx/conf/waf/wafconf/"
+        RulePath = "/usr/local/nginx/conf/waf/wafconf/"
         --规则存放目录
         attacklog = "off"
         --是否开启攻击信息记录，需要配置logdir
@@ -67,6 +67,8 @@ nginx安装路径假设为:/usr/local/nginx/conf/
         --ip白名单，多个ip用逗号分隔
         ipBlocklist={"1.0.0.1"}
         --ip黑名单，多个ip用逗号分隔
+        uriChecklist={"/users/sign_in", "/users/sign_up"}
+        --uri检查列表，同一个IP不能频繁请求这个列表中的uri，遵循CC的策略，多个uri用逗号分隔
         CCDeny="on"
         --是否开启拦截cc攻击(需要nginx.conf的http段增加lua_shared_dict limit 10m;)
         CCrate = "100/60"
@@ -102,18 +104,18 @@ nginx安装路径假设为:/usr/local/nginx/conf/
 
 ###一些说明：
 
-	过滤规则在wafconf下，可根据需求自行调整，每条规则需换行,或者用|分割
-	
-		global是全局过滤文件，里面的规则对post和get都过滤		
-		get是只在get请求过滤的规则		
-		post是只在post请求过滤的规则		
-		whitelist是白名单，里面的url匹配到不做过滤		
-		user-agent是对user-agent的过滤规则
-	
+    过滤规则在wafconf下，可根据需求自行调整，每条规则需换行,或者用|分割
+    
+        global是全局过滤文件，里面的规则对post和get都过滤     
+        get是只在get请求过滤的规则        
+        post是只在post请求过滤的规则      
+        whitelist是白名单，里面的url匹配到不做过滤     
+        user-agent是对user-agent的过滤规则
+    
 
-	默认开启了get和post过滤，需要开启cookie过滤的，编辑waf.lua取消部分--注释即可
-	
-	日志文件名称格式如下:虚拟主机名_sec.log
+    默认开启了get和post过滤，需要开启cookie过滤的，编辑waf.lua取消部分--注释即可
+    
+    日志文件名称格式如下:虚拟主机名_sec.log
 
 
 ## Copyright
@@ -132,5 +134,5 @@ nginx安装路径假设为:/usr/local/nginx/conf/
     <td>License</td><td>MIT License</td>
   </tr>
 </table>
-	
+    
 感谢ngx_lua模块的开发者[@agentzh](https://github.com/agentzh/),春哥是我所接触过开源精神最好的人

--- a/config.lua
+++ b/config.lua
@@ -8,6 +8,7 @@ postMatch="on"
 whiteModule="on" 
 ipWhitelist={"127.0.0.1"}
 ipBlocklist={"1.0.0.1"}
+uriChecklist={"/users/sign_in", "/users/sign_up"}
 CCDeny="off"
 CCrate="100/60"
 html=[[Please go away~~ ]]


### PR DESCRIPTION
因为最近我的服务器遭受到几百个IP规模的CC攻击
攻击特点是，多个链接轮训的加入了一个时间戳的参数，所以导致现有的denycc无效。

于是我针对我碰到的情况，加入了这个特性：
1. 只要频繁的请求uriChecklist中的uri（只要以配置的uri开始），就遵循denycc的策略，将其视为是请求同一个链接。
然后请求者的IP加入ipBlocklist，最后执行blockip()

blockip()应该是被遗漏了，不然我也不会在denycc()里面直接调用。
这样直接导致了没有开启denycc，IP黑名单功能也失效。所以这里应该是一个Bug.

denycc的改善想法
如果只有几个页面链接，没有JavaScript，样式，图片等资源文件的频繁请求，就可以当作是攻击者IP处理，这样对于web系统来说不会出现误判。
这个目前只是想法，有时间我去实践一下。

代码是临时学习Lua写的，所以质量可想象，甚至还有可能有严重的Bug。
