### PR TITLE
add host to whiteurl

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -11,4 +11,3 @@ ipBlocklist={"1.0.0.1"}
 CCDeny="off"
 CCrate="100/60"
 html=[[Please go away~~ ]]
-code=403

--- a/init.lua
+++ b/init.lua
@@ -72,7 +72,7 @@ function say_html()
     if Redirect then
         ngx.header.content_type = "text/html"
         ngx.say(html)
-        ngx.exit(code)
+        ngx.exit(200)
     end
 end
 


### PR DESCRIPTION
原whiteurl只支持目录，不支持hostname。
如nginx下面有多个hostname，无法单独加白名单。
修改后，whiteurl文件中可写：

abc.example.com/test
