### PR TITLE
fix upload file-suffix bug

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -93,7 +93,7 @@ function fileExtCheck(ext)
     local items = Set(black_fileExt)
     ext=string.lower(ext)
     if ext then
-        for rule in pairs(items) do
+        for rule,_ in pairs(items) do
             if ngx.re.match(ext,rule,"isjo") then
 	        log('POST',ngx.var.request_uri,"-","file attack with ext "..ext)
             say_html()

--- a/waf.lua
+++ b/waf.lua
@@ -42,7 +42,7 @@ elseif PostCheck then
 	   	        return true
     	    	end
 		size = size + len(data)
-		local m = ngxmatch(data,[[Content-Disposition: form-data;(.+)filename="(.+)\\.(.*)"]],'ijo')
+		local m = ngxmatch(data,[[Content-Disposition: form-data;(.+)filename="(.+)\.(.*)"]],'ijo')
         	if m then
             		fileExtCheck(m[3])
             		filetranslate = true


### PR DESCRIPTION
init.lua中fileExtCheck函数对后缀黑名单判断
waf.lua 对filename后缀转义\\. 在某些场景下有问题 \. 
望检查一下