### PR TITLE
Update init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -70,7 +70,7 @@ ckrules=read_rule('cookie')
 
 function say_html()
     if Redirect then
-        ngx.header.content_type = "text/html"
+        ngx.header.content_type = "text/html; charset=UTF-8"
         ngx.status = ngx.HTTP_FORBIDDEN
         ngx.say(html)
         ngx.exit(ngx.status)


### PR DESCRIPTION
设置输出字符集选项为UTF-8，使HTML页面在GBK字符集环境下也能够正确显示，避免乱码