### PR TITLE
增加白名单whiteurl功能。

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -78,9 +78,18 @@ function whiteurl()
     if WhiteCheck then
         if wturlrules ~=nil then
             for _,rule in pairs(wturlrules) do
-                if ngxmatch(ngx.var.uri,rule,"isjo") then
-                    return true 
-                 end
+            --针对site:开始的进行域名匹配。增加白名单用处。
+	        local sitemod,_=string.find(rule,"site:")
+	        if sitemod==1 then
+	        	rule=string.gsub(rule,"site:","",1)
+	        	if ngxmatch(ngx.var.host..ngx.var.uri,rule,"isjo") then
+                    	return true 
+                	end
+	        else
+            		if ngxmatch(ngx.var.uri,rule,"isjo") then
+                    	return true 
+                	end
+            	end
             end
         end
     end


### PR DESCRIPTION
`增加白名单功能。
whiteurl文件中使用site:^www\.abc\.com\/aa\/bb\/cc\.html$针对域名地址www.abc.com/aa/bb/cc.html做白名单限制。
site:^www\.abc\.com\/.* 直接就域名白名单？（没测试过）`
